### PR TITLE
:bug: Fix GitHub Pages demo import

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,14 @@ detail: {
 
 ## Live demos
 
-- [GitHub Pages](https://19h47.github.io/19h47-calendar/)
+- [GitHub Pages](https://19h47.github.io/19h47-calendar/) (from `docs/`)
 - Local: `pnpm dev` then open the app (see `index.html`)
+
+Refresh the Pages demo after lib changes:
+
+```bash
+pnpm run docs
+```
 
 ## Acknowledgments
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -431,7 +431,7 @@
 
 
 	<script type="module">
-		import Calendar, { getWeekStart } from './lib/index.ts';
+		import Calendar, { getWeekStart } from './calendar.js';
 
 		const flights = [
 			{

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 	"scripts": {
 		"deploy": "pnpm login && pnpm run build && pnpm publish",
 		"dev": "vite",
-		"build": "vite build"
+		"build": "vite build",
+		"docs": "pnpm run build && cp dist/calendar.js docs/calendar.js && sed \"s|from './lib/index.ts'|from './calendar.js'|\" index.html > docs/index.html"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Load the built calendar.js in docs instead of the Vite-only TypeScript entry.